### PR TITLE
fix(metadata): 修复_reference_url从knowledge对象获取改为从metadata获取

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "whiskerrag"
-version = "0.2.15"
+version = "0.2.16"
 description = "A utlity package for RAG operations"
 authors = ["petercat.ai <antd.antgroup@gmail.com>"]
 readme = "README.md"

--- a/src/whiskerrag_utils/__init__.py
+++ b/src/whiskerrag_utils/__init__.py
@@ -39,7 +39,7 @@ def _process_metadata_and_tags(
     """
     combined_metadata = {**knowledge.metadata, **parse_item.metadata}
     combined_metadata["_knowledge_type"] = knowledge.knowledge_type
-    combined_metadata["_reference_url"] = getattr(knowledge, "reference_url", "")
+    combined_metadata["_reference_url"] = combined_metadata.get("_reference_url", "")
 
     # Extract tags from metadata
     tags = combined_metadata.get("_tags")

--- a/tests/whiskerrag_utils/loader/test_text_loader.py
+++ b/tests/whiskerrag_utils/loader/test_text_loader.py
@@ -15,7 +15,9 @@ knowledge_data = {
     "source_config": {"text": "hello world"},
     "embedding_model_name": "openai",
     "tenant_id": "38fbd78b-1869-482c-9142-e43a2c2s6e42",
-    "metadata": {},
+    "metadata": {
+        "_reference_url": "test",
+    },
 }
 
 
@@ -30,3 +32,4 @@ class TestTextLoader:
         )
         res = await LoaderCls(knowledge).load()
         assert res[0].content == "hello world"
+        assert res[0].metadata["_reference_url"] == "test"

--- a/tests/whiskerrag_utils/parser/test_text_splitter.py
+++ b/tests/whiskerrag_utils/parser/test_text_splitter.py
@@ -25,20 +25,23 @@ class TestTextSplitter:
             "source_config": {"text": "hello world"},
             "embedding_model_name": "openai",
             "tenant_id": "38fbd78b-1869-482c-9142-e43a2c2s6e42",
-            "metadata": {},
+            "metadata": {
+                "_reference_url": "test",
+            },
         }
 
         knowledge = Knowledge(**knowledge_data)
         init_register()
         SplitterCls = get_register(RegisterTypeEnum.PARSER, "text")
         res = await SplitterCls().parse(
-            knowledge, Text(content="hello world \n ~", metadata={})
+            knowledge,
+            Text(content="hello world \n ~", metadata={"_reference_url": "test"}),
         )
 
         assert res == [
-            Text(content="hello", metadata={}),
-            Text(content="world", metadata={}),
-            Text(content="~", metadata={}),
+            Text(content="hello", metadata={"_reference_url": "test"}),
+            Text(content="world", metadata={"_reference_url": "test"}),
+            Text(content="~", metadata={"_reference_url": "test"}),
         ]
 
     @pytest.mark.asyncio


### PR DESCRIPTION
修改_reference_url的获取逻辑，优先从combined_metadata中获取
更新相关测试用例以验证修改后的逻辑